### PR TITLE
fix for py3 (syntax error)

### DIFF
--- a/slabbe/double_square_tile.py
+++ b/slabbe/double_square_tile.py
@@ -1599,9 +1599,9 @@ class DoubleSquare(SageObject):
         """
         f = lambda x: numerical_approx(x,digits=3)
         step = numerical_approx(step, digits=4)
-        points = map(lambda (x,y):(x*step,y*step), list(self.boundary_word().points()))
+        points = [(x * step, y * step) for x, y in list(self.boundary_word().points())]
         l = [str(tuple(map(f, pt))) for pt in points]
-        s = '\\filldraw[%s, very thick, draw=black, fill=black!20] ' %arrow
+        s = '\\filldraw[%s, very thick, draw=black, fill=black!20] ' % arrow
         s += ' -- '.join(l) + ';'
         [a1, b1, a2, b2, a3, b3, a4, b4] = self.factorization_points()
         s += '\n  \\node[first] at %s {};'% (points[a1],)


### PR DESCRIPTION
because the first example in http://www.slabbe.org/blogue/2018/12/comparison-of-wang-tiling-solvers/

did not work..

```
sage: from slabbe import WangTileSet
  File "/home/chapoton/sage3/local/lib/python3.7/site-packages/slabbe/double_square_tile.py", line 1602
    points = map(lambda (x,y):(x*step,y*step), list(self.boundary_word().points()))
                        ^
SyntaxError: invalid syntax
```
